### PR TITLE
Refactor cancel_squad_testjobs.py

### DIFF
--- a/bin/cancel_squad_testjobs.py
+++ b/bin/cancel_squad_testjobs.py
@@ -23,10 +23,13 @@ def cancel_lava_jobs(url, project, build_version, identity=None):
         Note this doesn't handle duplicate project names well..
     """
 
-    base_url = squad_client.urljoiner(url, "/api/projects/")
+    base_url = squad_client.urljoiner(url, "api/projects/")
 
     params = {"slug": project}
-    project = squad_client.get_objects(base_url, True, params)[0]
+    try:
+        project = squad_client.get_objects(base_url, False, params)[0]
+    except:
+        exit("Error: project {} not found at {}".format(project, base_url))
     build_list = squad_client.get_objects(project["builds"], {"version": build_version})
     identity_argument = ""
     if identity:

--- a/docs/cancel_squad_testjobs.md
+++ b/docs/cancel_squad_testjobs.md
@@ -5,19 +5,44 @@ given qa-reports build.
 
 ## Example Usage
 
-Create a ~/.netrc, mode 600, with contents similar to the following. Note that password should not be your user password, but instead an API key available from the qa-reports or lava UI, accordingly.
-```
-machine qa-reports.linaro.org
-        login dan.rue@linaro.org
-        password XXX
+Set up [lavacli](https://pypi.org/project/lavacli/). Configuration instructions can be found [here](https://git.lavasoftware.org/lava/lavacli/blob/master/doc/configuration.rst).
 
-machine lkft.validation.linaro.org
-        login dan.rue
-        password XXX
-```
+Then, run cancel_squad_testjobs.py with a given url to a build. Use -i to pass
+a lavacli identity, if necessary.
 
-Then, provide the required arguments. For example:
 ```
-cancel_squad_testjobs.py --project-slug linux-stable-rc-4.4-oe --squad-url https://qa-reports.linaro.org --build-version v4.4.147-46-g41fa2bf55dc9
+drue@xps:~/src/lkft-tools$ cancel_squad_testjobs.py 'https://qa-reports.linaro.org/lkft/linux-stable-rc-4.14-oe/build/v4.14.105-132-g4dc8caa88c8b/'
+Skipping: 636948; status: Complete
+Skipping: 636947; status: Complete
+Skipping: 636946; status: Complete
+Skipping: 636945; status: Complete
+Skipping: 636944; status: Complete
+Skipping: 636943; status: Complete
+Skipping: 636942; status: Complete
+Skipping: 636941; status: Complete
+Skipping: 636940; status: Complete
+Skipping: 636939; status: Complete
+Skipping: 636938; status: Complete
+Skipping: 636937; status: Complete
+Skipping: 636936; status: Complete
+Skipping: 636935; status: Complete
+Skipping: 636931; status: Complete
+Skipping: 636930; status: Complete
+Skipping: 636929; status: Complete
+Skipping: 636928; status: Complete
+Skipping: 636927; status: Complete
+Skipping: 636926; status: Complete
+Skipping: 636925; status: Complete
+Skipping: 636924; status: Complete
+Skipping: 636923; status: Complete
+Skipping: 636922; status: Complete
+Skipping: 636921; status: Complete
+Skipping: 636920; status: Complete
+Skipping: 636919; status: Complete
+Skipping: 636918; status: Canceled
+Canceling: 636917
+lavacli  jobs cancel 636917
+Skipping: 636916; status: Complete
+...
 ```
 

--- a/lib/squad_client.py
+++ b/lib/squad_client.py
@@ -1,5 +1,7 @@
+import os
 import re
 import requests
+import yaml
 
 
 def get_projects_by_branch():
@@ -17,6 +19,46 @@ def get_projects_by_branch():
         # which branch to use
         "5.1": "https://qa-reports.linaro.org/api/projects/22/",
     }
+
+
+def get_domain_from_url(url):
+    """
+        Given a fully qualified http or https url, return the
+        domain name.
+        IN:
+            https://qa-reports.linaro.org/lkft/linux-stable-rc-4.9-oe/
+            https://qa-reports.linaro.org
+            http://qa-reports.linaro.org
+        OUT:
+            qa-reports.linaro.org
+    """
+    return re.match(r"https?://([^/$]*)", url).groups()[0]
+
+
+def get_squad_params_from_build_url(url):
+    """
+        Given a url to a build, return a tuple consisting of
+        (squad-url, group-slug, project-slug, build-version)
+
+        For example:
+        IN:
+            https://qa-reports.linaro.org/lkft/linux-stable-rc-4.9-oe/build/v4.9.162-94-g0384d1b03fc9/
+        OUT:
+            ('https://qa-reports.linaro.org',
+             'lkft',
+             'linux-stable-rc-4.9-oe',
+             'v4.9.162-94-g0384d1b03fc9'
+            )
+    """
+    return re.match(r"(https?://[^/$]*)/([^/]*)/([^/]*)/build/([^/]*)", url).groups()
+
+
+def urljoiner(*args):
+    """
+    Joins given arguments into an url. Trailing but not leading slashes are
+    stripped for each argument.
+    """
+    return "/".join(map(lambda x: str(x).rstrip("/"), args))
 
 
 def get_objects(endpoint_url, expect_one=False, parameters={}):

--- a/tests/test_squad_client.py
+++ b/tests/test_squad_client.py
@@ -1,0 +1,49 @@
+import os
+import sys
+
+sys.path.append(os.path.join(sys.path[0], "../", "lib"))
+import squad_client
+
+
+def test_get_domain_from_url_1():
+    domain = squad_client.get_domain_from_url(
+        "https://qa-reports.linaro.org/lkft/linux-stable-rc-4.9-oe/"
+    )
+    assert domain == "qa-reports.linaro.org"
+
+
+def test_get_domain_from_url_2():
+    domain = squad_client.get_domain_from_url("https://qa-reports.linaro.org")
+    assert domain == "qa-reports.linaro.org"
+
+
+def test_get_domain_from_url_3():
+    domain = squad_client.get_domain_from_url(
+        "http://qa-reports.linaro.org/lkft/linux-stable-rc-4.9-oe/"
+    )
+    assert domain == "qa-reports.linaro.org"
+
+
+def test_get_domain_from_url_4():
+    domain = squad_client.get_domain_from_url("http://qa-reports.linaro.org/")
+    assert domain == "qa-reports.linaro.org"
+
+
+def test_get_squad_params_from_build_url_1():
+    url = "https://qa-reports.linaro.org/lkft/linux-stable-rc-4.9-oe/build/v4.9.162-94-g0384d1b03fc9/"
+    assert squad_client.get_squad_params_from_build_url(url) == (
+        "https://qa-reports.linaro.org",
+        "lkft",
+        "linux-stable-rc-4.9-oe",
+        "v4.9.162-94-g0384d1b03fc9",
+    )
+
+
+def test_get_squad_params_from_build_url_2():
+    url = "https://qa-reports.linaro.org/lkft/linux-stable-rc-4.9-oe/build/v4.9.162-94-g0384d1b03fc9/#!?details=6233"
+    assert squad_client.get_squad_params_from_build_url(url) == (
+        "https://qa-reports.linaro.org",
+        "lkft",
+        "linux-stable-rc-4.9-oe",
+        "v4.9.162-94-g0384d1b03fc9",
+    )


### PR DESCRIPTION
- Change the interface. Now, only a build url is required.
- Change to use lavacli via subprocess. This hopefully simplifies things
and makes it more loosely coupled to LAVA implementation.
- Add some miscellaneous squad_client functions and tests.

Signed-off-by: Dan Rue <dan.rue@linaro.org>