### PR TITLE
[RFC] Use GitPython for list_rc_log

### DIFF
--- a/bin/list_rc_log.py
+++ b/bin/list_rc_log.py
@@ -44,8 +44,8 @@ if __name__ == "__main__":
     # Find oldest review request (will stop next search at this point)
     oldest = NOW
     for msgid in from_greg.keys():
-        msg = from_greg[msgid]["request"]
-        dt = stable_email.msg_get_dt(msg)
+        commit = from_greg[msgid]["request"]
+        dt = commit.committed_datetime
         if dt < oldest:
             oldest = dt
     print("Oldest: %s" % oldest)
@@ -56,9 +56,9 @@ if __name__ == "__main__":
     print("* Computing elapsed time...")
     rclog = {}
     for msgid in from_greg.keys():
-        request_msg = from_greg[msgid]["request"]
+        request_commit = from_greg[msgid]["request"]
 
-        r = stable_email.Review(request_msg, None)
+        r = stable_email.Review(request_commit, None)
         ymd = r.get_ymd()
         linux_ver = r.get_linux_version()
 

--- a/lib/stable_email.py
+++ b/lib/stable_email.py
@@ -120,12 +120,15 @@ class Review(object):
         if self.reply:
             reply_time = msg_get_dt(self.reply)
 
-        # This is a datetime.timedelta
-        diff = reply_time - request_time
-        self.elapsed_time = diff
+            # This is a datetime.timedelta
+            diff = reply_time - request_time
+            self.elapsed_time = diff
 
     def get_elapsed_time(self):
         self.calc_elapsed_time()
+
+        if not self.elapsed_time:
+            return None
 
         days = self.elapsed_time.days
         hours = days * 24
@@ -136,6 +139,10 @@ class Review(object):
     def get_sla_mark(self):
         self.calc_elapsed_time()
         et = self.elapsed_time
+
+        if not et:
+            return None
+
         hours = et.seconds / 3600
         if et.days >= 2:
             return ">48h"


### PR DESCRIPTION
wip: list_rc_log: Use GitPython to traverse public-inbox' collection of emails

Instead of fetching the file m from the Git repository using a subprocess (which we always knew was inefficient), use GitPython to directly go through all the commits available while looking for review requests and replies.

We still need to make email objects out of the git commits, but this is now done only on relevant commits, not all of them. This saves *a lot* of processing time.

With this change, the objects stored in the data structure are no longer email messages, but Git commits. Those Git commits can easily be converted to email messages with the `commit_to_email_message()` helper.

Still need to fix the proper setting of `git.Repo()`.