### PR TITLE
list_rc_log: Fix SLA token for getsla.py

### DIFF
--- a/bin/list_rc_log.py
+++ b/bin/list_rc_log.py
@@ -109,6 +109,6 @@ if __name__ == "__main__":
         print("### {}".format(date))
         for sla, releases in slas.items():
             print("#### {}".format(" ".join(releases)))
-            print("<!-- sla {} {} -->".format(sla, len(releases)))
+            print("<!-- sla {} {} -->".format(sla.strip('h'), len(releases)))
             print("- XXX in {}".format(sla))
         print("")


### PR DESCRIPTION
Instead of printing:
```
  <!-- sla <24h 3 -->
```
this now changes to:
```
<!-- sla <24 3 -->
```
so that it is compatible with `getsla.py` from lkft-website.