### PR TITLE
list_rc_log: Look 10 messages beyond limit date

### DIFF
--- a/lib/stable_email.py
+++ b/lib/stable_email.py
@@ -9,6 +9,7 @@ import email.policy
 
 import git
 
+OLD_MSGS_STREAK = 10
 
 def commit_to_email_message(commit):
     raw_msg = commit.tree["m"].data_stream.read()
@@ -50,9 +51,15 @@ def get_review_requests(dt_limit):
     repo = git.Repo(".")
     commits = repo.iter_commits("HEAD")
 
+    older_streak = 0
     for commit in commits:
         # Limit search
         if is_beyond_time_search(commit, dt_limit):
+            older_streak += 1
+        else:
+            older_streak = 0
+
+        if older_streak >= OLD_MSGS_STREAK:
             print("Done. Found %d review requests in %d messages." % (len(fg), x))
             break
 
@@ -72,9 +79,15 @@ def get_review_replies(oldest, fg):
     repo = git.Repo(".")
     commits = repo.iter_commits("HEAD")
 
+    older_streak = 0
     for commit in commits:
         # Limit search
         if is_beyond_time_search(commit, oldest):
+            older_streak += 1
+        else:
+            older_streak = 0
+
+        if older_streak >= OLD_MSGS_STREAK:
             print("Done. (Looked at %d messages.)" % x)
             break
 


### PR DESCRIPTION
Apparently, there are occasional glitches in the public-inbox repo of linux-stable. For instance:
```
  2019-12-17 10:18 -0800 Guenter Roeck    | Re: [PATCH 4.19 000/140] 4.19.90-stable review
  2019-12-17 10:18 -0800 Guenter Roeck    | Re: [PATCH 4.14 000/267] 4.14.159-stable review
  2019-12-17 11:03 -0700 Jerry Snitselaar | Re: [RFC PATCH] iommu/vt-d: avoid panic in __dmar_remove_one_dev_info
  2019-12-05 13:59 -0800 Yang Shi         | Re: [v3 PATCH] mm: move_pages: return valid node id in status if the page is already on the target node
  2019-11-28 08:47 -0700 shuah            | Re: [PATCH 5.3 00/95] 5.3.14-stable review
  2019-12-17 10:55 -0700 Jerry Snitselaar | [RFC PATCH] iommu/vt-d: avoid panic in __dmar_remove_one_dev_info
  2019-12-17 10:50 -0700 Jens Axboe       | Re: [PATCH] nbd: fix shutdown and recv work deadlock v2
```

That change from 2019-12-05 breaks the search for messages older than a certain date.

This commit changes the behavior by trying to get a streak of 10 consecutive messages that are older than the limit date.