### PR TITLE
cancel_squad_testjobs: Ignore jobs from remote LAVA servers

### DIFF
--- a/bin/cancel_squad_testjobs.py
+++ b/bin/cancel_squad_testjobs.py
@@ -51,6 +51,12 @@ def cancel_lava_jobs(url, project, build_version, identity=None, dryrun=False):
                     % (testjob["job_id"], testjob["job_status"])
                 )
                 continue
+
+            # backend 2 is lkft.validation.linaro.org, our home
+            if testjob["backend"] != "https://qa-reports.linaro.org/api/backends/2/":
+                print("Skipping: %s. Remote LAVA server." % testjob["job_id"])
+                continue
+
             print("Canceling: %s" % (testjob["job_id"]))
 
             cmd = "lavacli {} jobs cancel {}".format(


### PR DESCRIPTION
We may want to cancel all jobs from all labs, but at least today this will try to cancel jobs on the default LAVA instance configured in `lavacli`. That's wrong.

This will ignore remote jobs, which is at least an acknowledge that other labs exist. A follow up pull-request will implement support for canceling jobs of those remote labs.