### PR TITLE
Add build_info.py

### DIFF
--- a/bin/build_info.py
+++ b/bin/build_info.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+
+import argparse
+import os
+import sys
+
+sys.path.append(os.path.join(sys.path[0], "../", "lib"))
+import squad_client  # noqa: E402
+
+
+def print_build_info(url, build):
+    print("URL: %s" % url)
+    print("ID: %s" % build["id"])
+    print("Version: %s" % build["version"])
+    print("Project URL: %s" % build["project"])
+    print("Date: %s" % build["created_at"])
+    print("Finished: %s" % build["finished"])
+
+
+def print_build_info_row(build):
+    finished = "Finished"
+    if not build["finished"]:
+        finished = "Running"
+
+    print(
+        "%6d %-40s %-8s %s"
+        % (build["id"], build["version"], finished, build["created_at"])
+    )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("build_url", help="URL of the build")
+    parser.add_argument(
+        "--max-builds",
+        "-m",
+        default=10,
+        type=int,
+        help="Number of recent builds to look for information",
+    )
+    args = parser.parse_args()
+
+    try:
+        (
+            url,
+            group,
+            project,
+            build_version,
+        ) = squad_client.get_squad_params_from_build_url(args.build_url)
+    except:
+        sys.exit("Error parsing url: {}".format(args.build_url))
+
+    # Determine group ID
+    base_url = squad_client.urljoiner(url, "api/groups/")
+    params = {"slug": group}
+    try:
+        group_object = squad_client.get_objects(base_url, params)[0]
+    except:
+        exit("Error: group {} not found at {}".format(project, base_url))
+    group_id = group_object["id"]
+
+    # Get builds URL for the given group/project
+    base_url = squad_client.urljoiner(url, "api/projects/")
+    params = {"slug": project, "group": group_id}
+    try:
+        project_info = squad_client.get_objects(base_url, params)[0]
+    except:
+        exit("Error: project {} not found at {}".format(project, base_url))
+
+    # Get list of builds for that group/project
+    build_list = squad_client.get_objects(
+        project_info["builds"],
+        parameters={"version": build_version},
+        limit=args.max_builds,
+    )
+
+    main_build = None
+    for build in build_list:
+        if build["version"] == build_version:
+            main_build = build
+
+    if main_build:
+        print_build_info(args.build_url, main_build)
+        print("")
+
+    print("Other builds from the same project:")
+    for build in build_list:
+        print_build_info_row(build)

--- a/bin/cancel_squad_testjobs.py
+++ b/bin/cancel_squad_testjobs.py
@@ -33,7 +33,7 @@ def cancel_lava_jobs(
 
     params = {"slug": group}
     try:
-        group_object = squad_client.get_objects(base_url, False, params)[0]
+        group_object = squad_client.get_objects(base_url, params)[0]
     except:
         exit("Error: group {} not found at {}".format(project, base_url))
 
@@ -43,7 +43,7 @@ def cancel_lava_jobs(
 
     params = {"slug": project, "group": group_id}
     try:
-        project = squad_client.get_objects(base_url, False, params)[0]
+        project = squad_client.get_objects(base_url, params)[0]
     except:
         exit("Error: project {} not found at {}".format(project, base_url))
     build_list = squad_client.get_objects(project["builds"], {"version": build_version})

--- a/bin/generate_lkft_tested_report.py
+++ b/bin/generate_lkft_tested_report.py
@@ -34,7 +34,7 @@ def get_test_count(builds):
     test_count = 0
     test_run_count = 0
     for build in builds:
-        status = squad_client.get_objects(build["status"], expect_one=True)
+        status = squad_client.get_objects(build["status"], limit=1)
         test_run_count += status.get("test_runs_total", 0)
         test_count += (
             status["tests_pass"] + status["tests_fail"] + status["tests_xfail"]
@@ -44,7 +44,7 @@ def get_test_count(builds):
 
 def get_project_name(project_url):
     """ Given a squad project url, return the project name """
-    return squad_client.get_objects(project_url, expect_one=True)["name"]
+    return squad_client.get_objects(project_url, limit=1)["name"]
 
 
 def valid_date_type(arg_date_str):

--- a/lib/squad_client.py
+++ b/lib/squad_client.py
@@ -66,24 +66,26 @@ def urljoiner(*args):
     return "/".join(map(lambda x: str(x).rstrip("/"), args))
 
 
-def get_objects(endpoint_url, expect_one=False, parameters={}):
+def get_objects(endpoint_url, parameters={}, limit=0):
     """
     gets list of objects from endpoint_url
     optional parameters allow for filtering
     expect_count
     """
+    if limit:
+        parameters["limit"] = limit
     obj_r = requests.get(endpoint_url, parameters)
     if obj_r.status_code == 200:
         objs = obj_r.json()
         if "count" in objs.keys():
-            if expect_one and objs["count"] == 1:
+            if limit == 1 and objs["count"] == 1:
                 return objs["results"][0]
             else:
                 ret_obj = []
                 while True:
                     for obj in objs["results"]:
                         ret_obj.append(obj)
-                    if objs["next"] is None:
+                    if objs["next"] is None or len(ret_obj) == limit:
                         break
                     else:
                         obj_r = requests.get(objs["next"])

--- a/lib/squad_client.py
+++ b/lib/squad_client.py
@@ -66,7 +66,7 @@ def urljoiner(*args):
     return "/".join(map(lambda x: str(x).rstrip("/"), args))
 
 
-def get_objects(endpoint_url, parameters={}, limit=0):
+def get_objects(endpoint_url, parameters={}, limit=None):
     """
     gets list of objects from endpoint_url
     optional parameters allow for filtering


### PR DESCRIPTION
This script will gather information about the given build (in the form of a URL) and some related builds. E.g.:
```
$ ./build_info.py https://qa-reports.linaro.org/lkft/linux-stable-rc-5.4-oe/build/v5.4.12/
URL: https://qa-reports.linaro.org/lkft/linux-stable-rc-5.4-oe/build/v5.4.12/
ID: 28941
Version: v5.4.12
Project URL: https://qa-reports.linaro.org/api/projects/232/
Date: 2020-01-15T17:06:59.657403Z
Finished: False

Other builds from the same project:
 28964 v5.4.12-2-g7f1b8631b5a5                  Running  2020-01-15T19:00:24.289329Z
 28941 v5.4.12                                  Running  2020-01-15T17:06:59.657403Z
 28874 v5.4.11-79-gf2a80321e1ca                 Running  2020-01-14T21:14:24.942193Z
 28838 v5.4.11-79-g5c903e10834d                 Running  2020-01-14T11:18:41.005464Z
 28803 v5.4.11-65-gfc79c2294846                 Finished 2020-01-14T01:05:35.120849Z
 28742 v5.4.11                                  Finished 2020-01-13T08:13:40.163672Z
 28682 v5.4.10-166-ged7e2ecd1b93                Finished 2020-01-11T11:04:52.926298Z
 28633 v5.4.10-137-g682b36a6e970                Finished 2020-01-10T14:02:04.729108Z
 28604 v5.4.10-137-gba0685a72f10                Finished 2020-01-10T09:47:40.908214Z
 28555 v5.4.10-136-gc2277d07f243                Finished 2020-01-09T22:14:01.360152Z
```

This is handy when build ID is required, as it's hard to get out of SQUAD through the web page.