### PR TITLE
docs: Bump LAVA priority of 4.4

### DIFF
--- a/docs/lava-job-priority.md
+++ b/docs/lava-job-priority.md
@@ -19,13 +19,13 @@ requirements, and it fully takes advantage of having 101 priorities available.
   - stable-rc sanity jobs (all branches)
   - mainline sanity jobs
 - 79: [Developer builder](developer-builder.md) jobs
+- 78: stable-rc-4.4
 - 77: stable-rc-4.9
 - 76: stable-rc-4.14
 - 75: stable-rc-4.19
 - 74: stable-rc 5.4
 - 73: reserved for 2020 LTS kernel (perhaps 5.9?)
 - 72: stable branches which are not LTS (e.g. 5.x)
-- 71: stable-rc-4.4
 - 50: AOSP jobs
 - 30: linux-next sanity jobs
 - 25:


### PR DESCRIPTION
As mentioned in this comment:
  https://github.com/Linaro/lkft-tools/pull/40#issuecomment-582060681
it would be better if priority for 4.4 is similar to the one from jobs for 4.9, due to those branches being released in tandem, generally.