### PR TITLE
cancel_squad_testjobs: Fetch 50 jobs at most

### DIFF
--- a/bin/cancel_squad_testjobs.py
+++ b/bin/cancel_squad_testjobs.py
@@ -54,7 +54,7 @@ def cancel_lava_jobs(
     except Exception:
         exit("Error: project {} not found at {}".format(project, base_url))
     build_list = lkft_squad_client.get_objects(
-        project["builds"], {"version": build_version}
+        project["builds"], {"version": build_version}, limit=50
     )
     identity_argument = ""
     if identity:


### PR DESCRIPTION
We usually have 3 or 4 running jobs when we need to cancel previous runs. There is no need to fetch the entire list of jobs when only maybe 5 are still running.