### PR TITLE
Rename squad_client to lkft_squad_client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 all: test black flake8
+	@echo "🚀😀👌😍🚀"
 
 test:
 	pytest

--- a/bin/build_info.py
+++ b/bin/build_info.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 
 import argparse
 import os
 import sys
 
 sys.path.append(os.path.join(sys.path[0], "../", "lib"))
-import squad_client  # noqa: E402
+import lkft_squad_client  # noqa: E402
 
 
 def print_build_info(url, build):
@@ -46,29 +47,29 @@ if __name__ == "__main__":
             group,
             project,
             build_version,
-        ) = squad_client.get_squad_params_from_build_url(args.build_url)
-    except:
+        ) = lkft_squad_client.get_squad_params_from_build_url(args.build_url)
+    except Exception:
         sys.exit("Error parsing url: {}".format(args.build_url))
 
     # Determine group ID
-    base_url = squad_client.urljoiner(url, "api/groups/")
+    base_url = lkft_squad_client.urljoiner(url, "api/groups/")
     params = {"slug": group}
     try:
-        group_object = squad_client.get_objects(base_url, params)[0]
-    except:
+        group_object = lkft_squad_client.get_objects(base_url, params)[0]
+    except Exception:
         exit("Error: group {} not found at {}".format(project, base_url))
     group_id = group_object["id"]
 
     # Get builds URL for the given group/project
-    base_url = squad_client.urljoiner(url, "api/projects/")
+    base_url = lkft_squad_client.urljoiner(url, "api/projects/")
     params = {"slug": project, "group": group_id}
     try:
-        project_info = squad_client.get_objects(base_url, params)[0]
-    except:
+        project_info = lkft_squad_client.get_objects(base_url, params)[0]
+    except Exception:
         exit("Error: project {} not found at {}".format(project, base_url))
 
     # Get list of builds for that group/project
-    build_list = squad_client.get_objects(
+    build_list = lkft_squad_client.get_objects(
         project_info["builds"],
         parameters={"version": build_version},
         limit=args.max_builds,

--- a/bin/generate_lkft_tested_report.py
+++ b/bin/generate_lkft_tested_report.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 
 """
     Generate a report for the purposes of jipdate status (for JIRA).
@@ -27,14 +28,14 @@ import sys
 from urllib.parse import urljoin
 
 sys.path.append(os.path.join(sys.path[0], "../", "lib"))
-import squad_client  # noqa: E402
+import lkft_squad_client  # noqa: E402
 
 
 def get_test_count(builds):
     test_count = 0
     test_run_count = 0
     for build in builds:
-        status = squad_client.get_objects(build["status"], limit=1)
+        status = lkft_squad_client.get_objects(build["status"], limit=1)
         test_run_count += status.get("test_runs_total", 0)
         test_count += (
             status["tests_pass"] + status["tests_fail"] + status["tests_xfail"]
@@ -44,14 +45,14 @@ def get_test_count(builds):
 
 def get_project_name(project_url):
     """ Given a squad project url, return the project name """
-    return squad_client.get_objects(project_url, limit=1)["name"]
+    return lkft_squad_client.get_objects(project_url, limit=1)["name"]
 
 
 def valid_date_type(arg_date_str):
     """custom argparse *date* type for user dates values given from the command line"""
     try:
         return datetime.datetime.strptime(arg_date_str, "%Y-%m-%d")
-    except:
+    except Exception:
         print(
             "Given Date ({0}) not valid! Expected format, YYYY-MM-DD!".format(
                 arg_date_str
@@ -73,7 +74,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
     date = args.date
 
-    branches = squad_client.get_projects_by_branch()
+    branches = lkft_squad_client.get_projects_by_branch()
 
     test_count_total = 0
     test_run_total = 0
@@ -81,7 +82,7 @@ if __name__ == "__main__":
     for branch, branch_url in branches.items():
         builds_url = urljoin(branch_url, "builds")
         builds_to_report = []
-        for build in squad_client.Builds(builds_url):
+        for build in lkft_squad_client.Builds(builds_url):
             if date > datetime.datetime.strptime(
                 build["datetime"], "%Y-%m-%dT%H:%M:%S.%fZ"
             ):

--- a/bin/generate_lts_report.py
+++ b/bin/generate_lts_report.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 
 import argparse
 import os
@@ -9,7 +10,7 @@ import time
 from urllib.parse import urljoin
 
 sys.path.append(os.path.join(sys.path[0], "../", "lib"))
-import squad_client  # noqa: E402
+import lkft_squad_client  # noqa: E402
 
 
 def extract_version_info(version):
@@ -66,7 +67,7 @@ def detect_baseline(build_result, builds_url):
 
     # Find the previous release, or, where patch number decriments in the event
     # there was not a tagged release.
-    for build in squad_client.Builds(builds_url):
+    for build in lkft_squad_client.Builds(builds_url):
         (
             build_major,
             build_minor,
@@ -99,7 +100,7 @@ def get_build_report(
 
     builds_url = urljoin(project_url, "builds")
     build_result = None
-    for build in squad_client.Builds(builds_url):
+    for build in lkft_squad_client.Builds(builds_url):
         if not build_id:
             build_result = build
             break
@@ -159,11 +160,9 @@ if __name__ == "__main__":
     # List of possible branches.
     # To add a branch, navigate in browser to
     # https://qa-reports.linaro.org/api/projects/.
-    projects = squad_client.get_projects_by_branch()
+    projects = lkft_squad_client.get_projects_by_branch()
     available_branches = projects.keys()
-    branch_help = (
-        "[" + "|".join(available_branches) + "]"
-    )
+    branch_help = "[" + "|".join(available_branches) + "]"
 
     parser = argparse.ArgumentParser()
     parser.add_argument("branch", help=branch_help)

--- a/bin/generate_next_kselftest_report.py
+++ b/bin/generate_next_kselftest_report.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 
 import argparse
 import os
@@ -7,7 +8,7 @@ import sys
 import time
 
 sys.path.append(os.path.join(sys.path[0], "../", "lib"))
-import squad_client  # noqa: E402
+import lkft_squad_client  # noqa: E402
 
 project_url = "https://qa-reports.linaro.org/api/projects/6/"  # linux-next-oe
 template_id = "12"  # kselftest-specific template
@@ -22,7 +23,7 @@ def get_build_report(
 
     builds_url = project_url + "builds"
     build_result = None
-    for build in squad_client.Builds(builds_url):
+    for build in lkft_squad_client.Builds(builds_url):
         if not build_id:
             build_result = build
             break

--- a/bin/list_rc_log.py
+++ b/bin/list_rc_log.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 
 import argparse
 import datetime
@@ -109,6 +110,6 @@ if __name__ == "__main__":
         print("### {}".format(date))
         for sla, releases in slas.items():
             print("#### {}".format(" ".join(releases)))
-            print("<!-- sla {} {} -->".format(sla.strip('h'), len(releases)))
+            print("<!-- sla {} {} -->".format(sla.strip("h"), len(releases)))
             print("- XXX in {}".format(sla))
         print("")

--- a/bin/lkft_notify_developer.py
+++ b/bin/lkft_notify_developer.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 
 import argparse
 import os
@@ -7,7 +8,7 @@ import requests
 import sys
 
 sys.path.append(os.path.join(sys.path[0], "../", "lib"))
-import squad_client  # noqa: E402
+import lkft_squad_client  # noqa: E402
 
 
 def get_branch_from_make_kernelversion(make_kernelversion):
@@ -29,7 +30,7 @@ def get_most_recent_release(builds_url):
     """
 
     first_build = None
-    for build in squad_client.Builds(builds_url):
+    for build in lkft_squad_client.Builds(builds_url):
         if not first_build:
             first_build = build
         if build["finished"]:
@@ -40,13 +41,13 @@ def get_most_recent_release(builds_url):
 
 
 def get_build_report(build_url):
-    build = squad_client.Build(build_url)
+    build = lkft_squad_client.Build(build_url)
     baseline_branch = get_branch_from_make_kernelversion(
         build.build_metadata["make_kernelversion"]
     )
 
     # Get baseline
-    baseline_project_url = squad_client.get_projects_by_branch()[baseline_branch]
+    baseline_project_url = lkft_squad_client.get_projects_by_branch()[baseline_branch]
     baseline_builds_url = baseline_project_url + "builds"
     baseline_build = get_most_recent_release(baseline_builds_url)
 

--- a/bin/trigger_generate_next_kselftest_report.py
+++ b/bin/trigger_generate_next_kselftest_report.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 
 import datetime
 import os
@@ -6,7 +7,7 @@ import sys
 import yaml
 
 sys.path.append(os.path.join(sys.path[0], "../", "lib"))
-import squad_client  # noqa: E402
+import lkft_squad_client  # noqa: E402
 
 BUILDS_URL = "https://qa-reports.linaro.org/api/projects/6/builds/"
 STATE_FILE = "/var/tmp/trigger_generate_next_kselftest_report.notified"
@@ -38,7 +39,7 @@ if __name__ == "__main__":
     notified_builds = get_notified_builds(STATE_FILE)
 
     developer_builds_url = BUILDS_URL
-    builds = squad_client.Builds(developer_builds_url)
+    builds = lkft_squad_client.Builds(developer_builds_url)
     for build in builds:
         if build["id"] in notified_builds:
             # Skip builds that have already been notified

--- a/bin/trigger_lkft_notify_developer.py
+++ b/bin/trigger_lkft_notify_developer.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 
 import datetime
 import os
@@ -6,7 +7,7 @@ import sys
 import yaml
 
 sys.path.append(os.path.join(sys.path[0], "../", "lib"))
-import squad_client  # noqa: E402
+import lkft_squad_client  # noqa: E402
 
 BUILDS_URL = "https://qa-reports.linaro.org/api/projects/131/builds/"
 STATE_FILE = "/var/tmp/trigger_lkft_notify_developer.notified"
@@ -38,7 +39,7 @@ if __name__ == "__main__":
     notified_builds = get_notified_builds(STATE_FILE)
 
     developer_builds_url = BUILDS_URL
-    builds = squad_client.Builds(developer_builds_url)
+    builds = lkft_squad_client.Builds(developer_builds_url)
     for build in builds:
         if build["id"] in notified_builds:
             # Skip builds that have already been notified

--- a/lib/lkft_squad_client.py
+++ b/lib/lkft_squad_client.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import re
 import requests
 

--- a/lib/netrcauth.py
+++ b/lib/netrcauth.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import netrc
 
 from urllib.parse import urlsplit

--- a/lib/proxy.py
+++ b/lib/proxy.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 from xmlrpc import client as xmlrpclib
 from urllib.parse import urlsplit
 

--- a/lib/stable_email.py
+++ b/lib/stable_email.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 
 # This library is used to parse emails from a public-inbox feed. It is used
 # specifically for the linux stable mailing list

--- a/tests/test_lkft_notify_developer.py
+++ b/tests/test_lkft_notify_developer.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import os
 import sys
 

--- a/tests/test_squad_client.py
+++ b/tests/test_squad_client.py
@@ -1,37 +1,39 @@
+# -*- coding: utf-8 -*-
+
 import os
 import sys
 
 sys.path.append(os.path.join(sys.path[0], "../", "lib"))
-import squad_client
+import lkft_squad_client
 
 
 def test_get_domain_from_url_1():
-    domain = squad_client.get_domain_from_url(
+    domain = lkft_squad_client.get_domain_from_url(
         "https://qa-reports.linaro.org/lkft/linux-stable-rc-4.9-oe/"
     )
     assert domain == "qa-reports.linaro.org"
 
 
 def test_get_domain_from_url_2():
-    domain = squad_client.get_domain_from_url("https://qa-reports.linaro.org")
+    domain = lkft_squad_client.get_domain_from_url("https://qa-reports.linaro.org")
     assert domain == "qa-reports.linaro.org"
 
 
 def test_get_domain_from_url_3():
-    domain = squad_client.get_domain_from_url(
+    domain = lkft_squad_client.get_domain_from_url(
         "http://qa-reports.linaro.org/lkft/linux-stable-rc-4.9-oe/"
     )
     assert domain == "qa-reports.linaro.org"
 
 
 def test_get_domain_from_url_4():
-    domain = squad_client.get_domain_from_url("http://qa-reports.linaro.org/")
+    domain = lkft_squad_client.get_domain_from_url("http://qa-reports.linaro.org/")
     assert domain == "qa-reports.linaro.org"
 
 
 def test_get_squad_params_from_build_url_1():
     url = "https://qa-reports.linaro.org/lkft/linux-stable-rc-4.9-oe/build/v4.9.162-94-g0384d1b03fc9/"
-    assert squad_client.get_squad_params_from_build_url(url) == (
+    assert lkft_squad_client.get_squad_params_from_build_url(url) == (
         "https://qa-reports.linaro.org",
         "lkft",
         "linux-stable-rc-4.9-oe",
@@ -41,7 +43,7 @@ def test_get_squad_params_from_build_url_1():
 
 def test_get_squad_params_from_build_url_2():
     url = "https://qa-reports.linaro.org/lkft/linux-stable-rc-4.9-oe/build/v4.9.162-94-g0384d1b03fc9/#!?details=6233"
-    assert squad_client.get_squad_params_from_build_url(url) == (
+    assert lkft_squad_client.get_squad_params_from_build_url(url) == (
         "https://qa-reports.linaro.org",
         "lkft",
         "linux-stable-rc-4.9-oe",


### PR DESCRIPTION
Our name collides with the official squad client at
https://github.com/Linaro/squad-client. Rename our little library to
avoid the collision.

Fix up all test/flake8/black errors.

Signed-off-by: Dan Rue <dan.rue@linaro.org>