### PR TITLE
lava-job-priority: updating LAVA job priority

### DIFF
--- a/docs/lava-job-priority.md
+++ b/docs/lava-job-priority.md
@@ -19,9 +19,8 @@ requirements, and it fully takes advantage of having 101 priorities available.
   - stable-rc sanity jobs (all branches)
   - mainline sanity jobs
 - 79: [Developer builder](developer-builder.md) jobs
+- 78: stable-rc 5.7
 - 78: stable branches which are not LTS (e.g. 5.x)
-- 78: stable-rc 5.6
-- 77: stable-rc 5.5
 - 76: reserved for 2020 LTS kernel (perhaps 5.9?)
 - 75: stable-rc 5.4
 - 74: stable-rc-4.19
@@ -30,8 +29,8 @@ requirements, and it fully takes advantage of having 101 priorities available.
 - 71: stable-rc-4.4
 - 50: AOSP jobs
 - 30: linux-next sanity jobs
+- 26: linux-next regular jobs
 - 25:
-  - linux-next regular jobs
   - linux-mainline regular jobs
   - lkft-staging jobs
 
@@ -88,15 +87,9 @@ openembedded-lkft-linux-stable-rc-5.4.yaml-            default: '75'
 openembedded-lkft-linux-stable-rc-5.4.yaml:            name: SANITY_LAVA_JOB_PRIORITY
 openembedded-lkft-linux-stable-rc-5.4.yaml-            default: '80'
 --
-openembedded-lkft-linux-stable-rc-5.5.yaml:            name: LAVA_JOB_PRIORITY
-openembedded-lkft-linux-stable-rc-5.5.yaml-            default: '77'
+openembedded-lkft-linux-stable-rc-5.7.yaml:            name: LAVA_JOB_PRIORITY
+openembedded-lkft-linux-stable-rc-5.7.yaml-            default: '78'
 --
-openembedded-lkft-linux-stable-rc-5.5.yaml:            name: SANITY_LAVA_JOB_PRIORITY
-openembedded-lkft-linux-stable-rc-5.5.yaml-            default: '80'
---
-openembedded-lkft-linux-stable-rc-5.6.yaml:            name: LAVA_JOB_PRIORITY
-openembedded-lkft-linux-stable-rc-5.6.yaml-            default: '78'
---
-openembedded-lkft-linux-stable-rc-5.6.yaml:            name: SANITY_LAVA_JOB_PRIORITY
-openembedded-lkft-linux-stable-rc-5.6.yaml-            default: '80'
+openembedded-lkft-linux-stable-rc-5.7.yaml:            name: SANITY_LAVA_JOB_PRIORITY
+openembedded-lkft-linux-stable-rc-5.7.yaml-            default: '80'
 ```


### PR DESCRIPTION
Updating LAVA priorities and clean up old builds data.
And updating linux next priority to 26 which one above
mainline.

Signed-off-by: Naresh Kamboju <naresh.kamboju@linaro.org>