### PR TITLE
docs: Add 2020 LTS and few minor changes

### DIFF
--- a/docs/lava-job-priority.md
+++ b/docs/lava-job-priority.md
@@ -23,10 +23,10 @@ requirements, and it fully takes advantage of having 101 priorities available.
 - 77: stable branches which are not LTS (e.g. 5.x)
 - 76: reserved for 2020 LTS kernel (perhaps 5.9?)
 - 75: stable-rc 5.4
-- 74: stable-rc-4.19
-- 73: stable-rc-4.14
-- 72: stable-rc-4.9
-- 71: stable-rc-4.4
+- 74: stable-rc 4.19
+- 73: stable-rc 4.14
+- 72: stable-rc 4.9
+- 71: stable-rc 4.4
 - 60: higher priority AOSP jobs
 - 50: AOSP jobs
 - 30: linux-next sanity jobs

--- a/docs/lava-job-priority.md
+++ b/docs/lava-job-priority.md
@@ -19,8 +19,8 @@ requirements, and it fully takes advantage of having 101 priorities available.
   - stable-rc sanity jobs (all branches)
   - mainline sanity jobs
 - 79: [Developer builder](developer-builder.md) jobs
-- 78: stable branches which are not LTS (e.g. 5.x)
-- 77: stable branches which are not LTS (e.g. 5.x)
+- 78: stable branches which are not LTS (e.g. 5.12)
+- 77: stable branches which are not LTS (e.g. 5.11)
 - 76: stable-rc 5.10
 - 75: stable-rc 5.4
 - 74: stable-rc 4.19

--- a/docs/lava-job-priority.md
+++ b/docs/lava-job-priority.md
@@ -21,7 +21,7 @@ requirements, and it fully takes advantage of having 101 priorities available.
 - 79: [Developer builder](developer-builder.md) jobs
 - 78: stable branches which are not LTS (e.g. 5.x)
 - 77: stable branches which are not LTS (e.g. 5.x)
-- 76: reserved for 2020 LTS kernel (perhaps 5.9?)
+- 76: stable-rc 5.10
 - 75: stable-rc 5.4
 - 74: stable-rc 4.19
 - 73: stable-rc 4.14


### PR DESCRIPTION
* Add 5.10, 2020 LTS, to LAVA priorities
* Clean-up formatting for 4.x branches in LAVA priorities
* Lay out which stable branches get which priorities