### PR TITLE
doc: lava-job-priority: Update stable-rc 5.10 priority

### DIFF
--- a/docs/lava-job-priority.md
+++ b/docs/lava-job-priority.md
@@ -21,7 +21,7 @@ requirements, and it fully takes advantage of having 101 priorities available.
 - 79: [Developer builder](developer-builder.md) jobs
 - 78: stable branches which are not LTS (e.g. 5.x)
 - 77: stable branches which are not LTS (e.g. 5.x)
-- 76: reserved for 2020 LTS kernel (perhaps 5.9?)
+- 76: stable-rc 5.10
 - 75: stable-rc 5.4
 - 74: stable-rc-4.19
 - 73: stable-rc-4.14


### PR DESCRIPTION
The latest LTS stable-rc 5.10 lava job priority set to 76.

Signed-off-by: Naresh Kamboju <naresh.kamboju@linaro.org>