### PR TITLE
lava-job-priority.md: add the entry for AOSP lower priority jobs

### DIFF
--- a/docs/lava-job-priority.md
+++ b/docs/lava-job-priority.md
@@ -29,6 +29,7 @@ requirements, and it fully takes advantage of having 101 priorities available.
 - 71: stable-rc-4.4
 - 60: higher priority AOSP jobs
 - 50: AOSP jobs
+- 40: lower priority AOSP jobs
 - 30: linux-next sanity jobs
 - 26: linux-next regular jobs
 - 25:


### PR DESCRIPTION
for AOSP lower pritory jobs, the lowest will be 40

Signed-off-by: Yongqin Liu <yongqin.liu@linaro.org>